### PR TITLE
Corrects facebook link

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -11,5 +11,5 @@ Some links:
 
 - Please sign up on the [Student Union website](www.abersu.co.uk/societies/AberCompSoc/)
 - Join the [mailing list](https://groups.google.com/forum/#!forum/abercompsoc)
-- Find us [on facebook](www.facebook.com/groups/AberCompSoc/)
+- Find us [on facebook](https://www.facebook.com/groups/AberCompSoc/)
 - [On twitter](https://twitter.com/abercompsoc)


### PR DESCRIPTION
Previous link went to http://abercompsoc.github.io/about/www.facebook.com/groups/AberCompSoc/