### PR TITLE
Fixed change to SU url causing 404 error

### DIFF
--- a/about/index.md
+++ b/about/index.md
@@ -9,7 +9,7 @@ science, and all things related!
 
 Some links:
 
-- Please sign up on the [Student Union website](www.abersu.co.uk/societies/AberCompSoc/)
+- Please sign up on the [Student Union website](https://www.abersu.co.uk/society/abercompsoc/)
 - Join the [mailing list](https://groups.google.com/forum/#!forum/abercompsoc)
 - Find us [on facebook](https://www.facebook.com/groups/AberCompSoc/)
 - [On twitter](https://twitter.com/abercompsoc)


### PR DESCRIPTION
SU has changed its URL structure from societies to society so clicking on the link causes a 404 error.